### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/manifest.v2.schema.json
+
 packaging_format = 2
 
 id = "jellyseerr"
@@ -26,13 +28,13 @@ ram.runtime = "50M"
 [install]
     [install.domain]
     type = "domain"
-    
+
     [install.init_main_permission]
     type = "group"
     default = "visitors"
 
   [resources]
-   
+
     [resources.sources]
 
         [resources.sources.main]
@@ -44,9 +46,9 @@ ram.runtime = "50M"
     [resources.system_user]
 
     [resources.install_dir]
-    
+
     [resources.data_dir]
-   
+
     [resources.permissions]
     main.url = "/"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -41,18 +41,9 @@ ynh_script_progression --message="Setting up source files..." --weight=1
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..."
-	# Move old app dir
-	mv ${install_dir} ${install_dir}.old
 	
-# Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir="$install_dir" --full_replace=1
-
-# restore data
-	cp -a ${install_dir}.old/config ${install_dir}
-
-	# delete temp directory
-	ynh_secure_remove --file=${install_dir}.old
-fi
+	# Download, check integrity, uncompress and patch the source from app.src
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="$install_dir/config"
 
 chmod 750 "$install_dir"
 chmod -R o-rwx "$install_dir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -45,7 +45,7 @@ then
 	mv ${install_dir} ${install_dir}.old
 	
 # Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir" --full_replace=1
 
 # restore data
 	cp -a ${install_dir}.old/config ${install_dir}

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -37,13 +37,9 @@ ynh_npm install --global yarn
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=1
-
-if [ "$upgrade_type" == "UPGRADE_APP" ]
-then
-	ynh_script_progression --message="Upgrading source files..."
 	
-	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="$install_dir/config"
+# Download, check integrity, uncompress and patch the source from app.src
+ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="$install_dir/config"
 
 chmod 750 "$install_dir"
 chmod -R o-rwx "$install_dir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -39,7 +39,7 @@ ynh_npm install --global yarn
 ynh_script_progression --message="Setting up source files..." --weight=1
 	
 # Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="$install_dir/config"
+ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config"
 
 chmod 750 "$install_dir"
 chmod -R o-rwx "$install_dir"

--- a/tests.toml
+++ b/tests.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/tests.v1.schema.json
+
 test_format = 1.0
 
 [default]
@@ -5,13 +7,13 @@ test_format = 1.0
     # ------------
     # Tests to run
     # ------------
-    
+
 
     # -------------------------------
     # Default args to use for install
     # -------------------------------
-    
-  
+
+
     # -------------------------------
     # Commits to test upgrade from
     # -------------------------------


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```