### PR TITLE
Fixed `remove`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Jellyseerr for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/jellyseerr.svg)](https://dash.yunohost.org/appci/app/jellyseerr) ![Working status](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
+[![Integration level](https://dash.yunohost.org/integration/jellyseerr.svg)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/) ![Working status](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
 
 [![Install Jellyseerr with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=jellyseerr)
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,7 @@ No se debe editar a mano.
 
 # Jellyseerr para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/jellyseerr.svg)](https://dash.yunohost.org/appci/app/jellyseerr) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/jellyseerr.svg)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
 
 [![Instalar Jellyseerr con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=jellyseerr)
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,7 @@ EZ editatu eskuz.
 
 # Jellyseerr YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/jellyseerr.svg)](https://dash.yunohost.org/appci/app/jellyseerr) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
+[![Integrazio maila](https://dash.yunohost.org/integration/jellyseerr.svg)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
 
 [![Instalatu Jellyseerr YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=jellyseerr)
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,7 @@ Il NE doit PAS être modifié à la main.
 
 # Jellyseerr pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/jellyseerr.svg)](https://dash.yunohost.org/appci/app/jellyseerr) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
+[![Niveau d’intégration](https://dash.yunohost.org/integration/jellyseerr.svg)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
 
 [![Installer Jellyseerr avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=jellyseerr)
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,7 @@ NON debe editarse manualmente.
 
 # Jellyseerr para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/jellyseerr.svg)](https://dash.yunohost.org/appci/app/jellyseerr) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/jellyseerr.svg)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
 
 [![Instalar Jellyseerr con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=jellyseerr)
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,7 @@
 
 # YunoHost 上的 Jellyseerr
 
-[![集成程度](https://dash.yunohost.org/integration/jellyseerr.svg)](https://dash.yunohost.org/appci/app/jellyseerr) ![工作状态](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
+[![集成程度](https://dash.yunohost.org/integration/jellyseerr.svg)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/jellyseerr.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/jellyseerr.maintain.svg)
 
 [![使用 YunoHost 安装 Jellyseerr](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=jellyseerr)
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -48,7 +48,7 @@ ynh_remove_nodejs
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..."
 
-yunohost service remove $app --log="/var/log/$app/$app.log"
+yunohost service remove $app
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problem

- Uninstall leaves dead service integration in YNH, the log reads:

```
024-07-14 21:22:13,854: INFO - [###############++...] > Integrating service in YunoHost...
2024-07-14 21:22:13,854: DEBUG - + yunohost service remove jellyseerr --log=/var/log/jellyseerr/jellyseerr.log
2024-07-14 21:22:13,950: WARNING - usage: yunohost {service} ...
2024-07-14 21:22:13,950: WARNING -                 [-h] [--output-as {json,plain,none}] [--debug] [--quiet]
2024-07-14 21:22:13,950: WARNING -                 [--version] [--timeout ==SUPPRESS==]
2024-07-14 21:22:13,951: WARNING - yunohost: error: unrecognized arguments: --log=/var/log/jellyseerr/jellyseerr.log
```

reported [on forums](https://forum.yunohost.org/t/trying-to-get-rid-of-a-dead-service/30414)

## Solution

- Remove extra argument from call.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
