### PR TITLE
Generate and store API_KEY during install

### DIFF
--- a/conf/jellyseerr.conf
+++ b/conf/jellyseerr.conf
@@ -1,6 +1,7 @@
 ## Jellyseerr's default port is 5055, if you want to use both, change this.
 ## specify on which port to listen
 PORT=__PORT__
+API_KEY=__API_KEY__
 
 ## specify on which interface to listen, by default jellyseerr listens on all interfaces
 #HOST=127.0.0.1

--- a/scripts/install
+++ b/scripts/install
@@ -11,6 +11,9 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
+api_key=$(ynh_string_random --length=32)
+ynh_app_setting_set --app=$app --key="api_key" --value="$api_key"
+
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -19,6 +19,11 @@ ynh_systemctl --service="$app" --action="stop"
 #=================================================
 ynh_script_progression "Ensuring downward compatibility..."
 
+if [ -z "$(ynh_app_setting_get --app=$app --key=api_key)" ]; then
+	api_key=$(ynh_string_random --length=32)
+	ynh_app_setting_set --app=$app --key="api_key" --value="$api_key"
+fi
+
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,7 +22,7 @@ ynh_script_progression "Ensuring downward compatibility..."
 ynh_print_info "Adding an API_KEY if not set..."
 
 ynh_app_setting_set_default --app=$app --key="api_key" --value="$(ynh_string_random --length=32)"
-api_key=$(ynh_app_setting_get --app=$app --key=api_key)
+
 
 #=================================================
 # INSTALL DEPENDENCIES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -19,10 +19,9 @@ ynh_systemctl --service="$app" --action="stop"
 #=================================================
 ynh_script_progression "Ensuring downward compatibility..."
 
-if [ -z "$(ynh_app_setting_get --app=$app --key=api_key)" ]; then
-	api_key=$(ynh_string_random --length=32)
-	ynh_app_setting_set --app=$app --key="api_key" --value="$api_key"
-fi
+ynh_print_info "Adding an API_KEY if not set..."
+
+ynh_app_setting_set_default --app=$app --key="api_key" --value="$(ynh_string_random --length=32)"
 
 #=================================================
 # INSTALL DEPENDENCIES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,6 +22,7 @@ ynh_script_progression "Ensuring downward compatibility..."
 ynh_print_info "Adding an API_KEY if not set..."
 
 ynh_app_setting_set_default --app=$app --key="api_key" --value="$(ynh_string_random --length=32)"
+api_key=$(ynh_app_setting_get --app=$app --key=api_key)
 
 #=================================================
 # INSTALL DEPENDENCIES


### PR DESCRIPTION
## Problem

- *Jellyseerr doesn't generate and store API_KEY like Sonarr or Radarr. This impedes easier integration with apps like Janitorr and presumably other apps.*

## Solution

- *Add API_KEY env variable in jellyseerr.conf and generate an api_key during install.*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
