### PR TITLE
Bump Seerr to v3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 Previously Jellyseerr. Media request management and discovery tool for Jellyfin, Radarr, and Sonarr
 
-[![Version: 3.1.0~ynh1](https://img.shields.io/badge/Version-3.1.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/)
+[![Version: 3.1.1~ynh1](https://img.shields.io/badge/Version-3.1.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyseerr/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/jellyseerr"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Seerr"
 description.en = "Previously Jellyseerr. Media request management and discovery tool for Jellyfin, Radarr, and Sonarr"
 description.fr = "Anciennement Jellyseerr. Outil de gestion de demandes et de découverte de médias pour Jellyfin, Radarr, et Sonarr"
 
-version = "3.1.0~ynh1"
+version = "3.1.1~ynh1"
 
 maintainers = ["Thovi98"]
 
@@ -41,8 +41,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/seerr-team/seerr/archive/refs/tags/v3.1.0.tar.gz"
-    sha256 = "c19db0c92407f5c6363e7df8ca4e4ccae3f121e2b4f6baa2b4e269b197e2dd82"
+    url = "https://github.com/seerr-team/seerr/archive/refs/tags/v3.1.1.tar.gz"
+    sha256 = "30363ca76d887c28aecad86ce3eeec29ccff11af766c1895fc7476d37d786d72"
     autoupdate.strategy = "latest_github_tag"
 
 


### PR DESCRIPTION
## Problem

Seerr 3.1.0 appear to have critical CVE

## Solution

Bump Seerr to v3.1.1 to fix critical

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
